### PR TITLE
Attempt to fix deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: sudo apt-get update && sudo apt-get install -y rsync
+      - run: mv dist deploy
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: dist
+          folder: deploy


### PR DESCRIPTION
The deploy action apparently doesn't try to redeploy to `gh-pages` if the folder being deployed is in `.gitignore`. This should hopefully fix that.